### PR TITLE
Update path to redis config in sessions.js

### DIFF
--- a/config/session.js
+++ b/config/session.js
@@ -90,5 +90,5 @@ module.exports = {
   | the redis file. But you are free to define an object here too.
   |
   */
-  redis: 'self::redis.default'
+  redis: 'self::redis.local'
 }


### PR DESCRIPTION
When installing the Redis provider, a redis config file is being copied to `config/redis`. Contents of this file:
```
connection: ...,

locale: {
  ...
},

cluster: {
  ..
}
```

However, in the `config/sessions` file, there's a reference to `self::redis.default` (this is old I guess?) instead of `self::redis.local`. This update points to the right default redis config again.