### PR TITLE
Replace beforeCreate with beforeSave in User model

### DIFF
--- a/app/Models/User.js
+++ b/app/Models/User.js
@@ -13,7 +13,7 @@ class User extends Model {
      * Look at `app/Models/Hooks/User.js` file to
      * check the hashPassword method
      */
-    this.addHook('beforeCreate', 'User.hashPassword')
+    this.addHook('beforeSave', 'User.hashPassword')
   }
 
   /**


### PR DESCRIPTION
At this time the hook which hashes the password is `beforeCreate`, so we you update an existing user, it doesn't hash its password.
Changing it with `beforeSave` automatically hashes the password on creation and saving.