### PR TITLE
A little change to the arrow function (Placing parentheses)

### DIFF
--- a/database/migrations/1503248427885_user.js
+++ b/database/migrations/1503248427885_user.js
@@ -4,7 +4,7 @@ const Schema = use('Schema')
 
 class UserSchema extends Schema {
   up () {
-    this.create('users', table => {
+    this.create('users', (table) => {
       table.increments()
       table.string('username', 80).notNullable().unique()
       table.string('email', 254).notNullable().unique()


### PR DESCRIPTION
With the command `adonis make: migration` the function comes with the parentheses placed, I think that to standardize, it should be placed here as well.