### PR TITLE
Ignore VSCode & Webstorm history directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ tmp
 
 # The development sqlite file
 database/development.sqlite
+
+# VSCode & Webstorm history directories
+.history
+.idea


### PR DESCRIPTION
Committing history and other IDE/Editor files make problem in team projects.