### PR TITLE
Update session.js redis configuration

### DIFF
--- a/config/session.js
+++ b/config/session.js
@@ -91,5 +91,11 @@ module.exports = {
   | the redis file. But you are free to define an object here too.
   |
   */
-  redis: 'self::redis.local'
+  redis: {
+    host: '127.0.0.1',
+    port: 6379,
+    password: null,
+    db: 0,
+    keyPrefix: ''
+  }
 }


### PR DESCRIPTION
Updating the redis configuration in session.js to match the one in the adonis session repo.

Was getting issues with running redis with a password in prod due to this issue. I guess the self::redis.local doesn't actually resolve anymore?