### PR TITLE
gitignore all .sqlite files inside the database folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ tmp
 .env
 
 # The development sqlite file
-database/development.sqlite
+database/*.sqlite
 
 # VSCode & Webstorm history directories
 .history


### PR DESCRIPTION
The PR https://github.com/adonisjs/adonis-fullstack-app/commit/4a5bda073767903521ddf95f8cd647e3cec45cbd didn't take the `.gitignore` file into consideration. When running tests you might end up pushing the .sqlite file since it can have a different name than `development.sqlite`.